### PR TITLE
adds missing dependencies for manual install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,13 @@ moviepy
 opencv-python-headless
 natsort
 pyinstaller
+imageio
+natsort
+proglog
+tqdm
+imageio
+imageio-ffmpeg
+decorator
+pillow
+packaging
+darkdetect


### PR DESCRIPTION
There are several missing dependencies in the requirements.txt.

This CL fixes this and allows pip install -r requirements.txt && python FluidFrames.py to work correctly.